### PR TITLE
Add RBAC

### DIFF
--- a/cmd/mvmapi/add-role.go
+++ b/cmd/mvmapi/add-role.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"errors"
+
+	"github.com/moedersvoormoeders/api.mvm.digital/pkg/db"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func init() {
+	rootCmd.AddCommand(NewAddRoleCmd())
+}
+
+type addRoleCmdOptions struct {
+	Name      string
+	Verbs     []string
+	Endpoints []string
+
+	postgresHost     string
+	postgresPort     int
+	postgresUsername string
+	postgresDatabase string
+	postgresPassword string
+}
+
+// NewAddRoleCmd generates the `add-role` command
+func NewAddRoleCmd() *cobra.Command {
+	a := addRoleCmdOptions{}
+	c := &cobra.Command{
+		Use:     "add-role",
+		Short:   "adds a role to the database",
+		PreRunE: a.Validate,
+		RunE:    a.RunE,
+	}
+	c.Flags().StringVar(&a.postgresHost, "postgres-host", "", "PostgreSQL hostname")
+	c.Flags().IntVar(&a.postgresPort, "postgres-port", 5432, "PostgreSQL hostname")
+	c.Flags().StringVar(&a.postgresUsername, "postgres-username", "", "PostgreSQL hostname")
+	c.Flags().StringVar(&a.postgresPassword, "postgres-password", "", "PostgreSQL hostname")
+	c.Flags().StringVar(&a.postgresDatabase, "postgres-database", "", "PostgreSQL hostname")
+
+	c.Flags().StringVar(&a.Name, "name", "", "Role name")
+	c.Flags().StringSliceVar(&a.Verbs, "verbs", nil, "Role allowed verbs")
+	c.Flags().StringSliceVar(&a.Endpoints, "endpoints", nil, "Role allowed endpoints")
+
+	viper.BindPFlags(c.Flags())
+
+	return c
+}
+
+func (a *addRoleCmdOptions) Validate(cmd *cobra.Command, args []string) error {
+	if a.Name == "" || len(a.Endpoints) == 0 || len(a.Verbs) == 0 {
+		return errors.New("--name, --endpoints and --verbs are required")
+	}
+	return nil
+}
+
+func (a *addRoleCmdOptions) RunE(cmd *cobra.Command, args []string) error {
+	dbConn, err := db.NewConnection(db.ConnectionDetails{
+		Host:     a.postgresHost,
+		Port:     a.postgresPort,
+		User:     a.postgresUsername,
+		Database: a.postgresDatabase,
+		Password: a.postgresPassword,
+	})
+
+	if err != nil {
+		return err
+	}
+
+	role := db.Role{
+		Name: a.Name,
+	}
+
+	res := dbConn.Create(&role)
+	if res.Error != nil {
+		return err
+	}
+
+	for _, verb := range a.Verbs {
+		res := dbConn.Create(&db.RoleVerb{
+			Content:   verb,
+			RoleRefer: role.ID,
+		})
+		if res.Error != nil {
+			return err
+		}
+	}
+
+	for _, endpoint := range a.Endpoints {
+		res := dbConn.Create(&db.RoleEndpoint{
+			Content:   endpoint,
+			RoleRefer: role.ID,
+		})
+		if res.Error != nil {
+			return err
+		}
+	}
+
+	return res.Error
+}

--- a/cmd/mvmapi/add-rolebinding.go
+++ b/cmd/mvmapi/add-rolebinding.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"errors"
+
+	"github.com/moedersvoormoeders/api.mvm.digital/pkg/db"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func init() {
+	rootCmd.AddCommand(NewAddRoleBindingCmd())
+}
+
+type addRoleBindingCmdOptions struct {
+	User string
+	Role string
+
+	postgresHost     string
+	postgresPort     int
+	postgresUsername string
+	postgresDatabase string
+	postgresPassword string
+}
+
+// NewAddRoleBindingCmd generates the `add-rolebinding` command
+func NewAddRoleBindingCmd() *cobra.Command {
+	a := addRoleBindingCmdOptions{}
+	c := &cobra.Command{
+		Use:     "add-rolebinding",
+		Short:   "adds a rolebinding to the database",
+		PreRunE: a.Validate,
+		RunE:    a.RunE,
+	}
+	c.Flags().StringVar(&a.postgresHost, "postgres-host", "", "PostgreSQL hostname")
+	c.Flags().IntVar(&a.postgresPort, "postgres-port", 5432, "PostgreSQL hostname")
+	c.Flags().StringVar(&a.postgresUsername, "postgres-username", "", "PostgreSQL hostname")
+	c.Flags().StringVar(&a.postgresPassword, "postgres-password", "", "PostgreSQL hostname")
+	c.Flags().StringVar(&a.postgresDatabase, "postgres-database", "", "PostgreSQL hostname")
+
+	c.Flags().StringVar(&a.User, "user", "", "User name")
+	c.Flags().StringVar(&a.Role, "role", "", "Role name")
+
+	viper.BindPFlags(c.Flags())
+
+	return c
+}
+
+func (a *addRoleBindingCmdOptions) Validate(cmd *cobra.Command, args []string) error {
+	if a.User == "" || a.Role == "" {
+		return errors.New("--user and --name are required")
+	}
+	return nil
+}
+
+func (a *addRoleBindingCmdOptions) RunE(cmd *cobra.Command, args []string) error {
+	dbConn, err := db.NewConnection(db.ConnectionDetails{
+		Host:     a.postgresHost,
+		Port:     a.postgresPort,
+		User:     a.postgresUsername,
+		Database: a.postgresDatabase,
+		Password: a.postgresPassword,
+	})
+
+	if err != nil {
+		return err
+	}
+
+	user := db.User{}
+	res := dbConn.Where(db.User{Name: a.User}).Find(&user)
+	if res.Error != nil {
+		return res.Error
+	} else if res.RowsAffected == 0 {
+		return errors.New("No user found")
+	}
+
+	role := db.Role{}
+	res = dbConn.Where(db.Role{Name: a.Role}).Find(&role)
+	if res.Error != nil {
+		return res.Error
+	} else if res.RowsAffected == 0 {
+		return errors.New("No role found")
+	}
+
+	roleb := db.RoleBinding{
+		User: user,
+		Role: role,
+	}
+
+	res = dbConn.Create(&roleb)
+
+	return res.Error
+}

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/didip/tollbooth v4.0.2+incompatible
 	github.com/didip/tollbooth_echo v0.0.0-20190918161726-5adbfff23d88
+	github.com/gobwas/glob v0.2.3
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/jinzhu/gorm v1.9.16
 	github.com/labstack/echo/v4 v4.1.17

--- a/go.sum
+++ b/go.sum
@@ -146,6 +146,8 @@ github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG
 github.com/go-sql-driver/mysql v1.5.0 h1:ozyZYNQW3x3HtqT1jira07DN2PArx2v7/mN66gGcHOs=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
+github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gofrs/uuid v3.2.0+incompatible h1:y12jRkkFxsd7GpqdSZ+/KCs/fJbqpEXSGd4+jfEaewE=
 github.com/gofrs/uuid v3.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=

--- a/pkg/api/auth/jwt.go
+++ b/pkg/api/auth/jwt.go
@@ -6,6 +6,7 @@ import (
 
 type Claim struct {
 	Name string `json:"name"`
+	ID   uint   `json:"id"`
 	// TODO: roles
 	jwt.StandardClaims
 }

--- a/pkg/api/v1/http.go
+++ b/pkg/api/v1/http.go
@@ -1,14 +1,9 @@
 package v1
 
 import (
-	"net/http"
-
 	"github.com/moedersvoormoeders/api.mvm.digital/pkg/db"
 
-	"github.com/dgrijalva/jwt-go"
 	"github.com/labstack/echo/v4"
-
-	"github.com/moedersvoormoeders/api.mvm.digital/pkg/api/auth"
 )
 
 type HTTPHandler struct {
@@ -22,20 +17,14 @@ func NewHTTPHandler(db *db.Connection) *HTTPHandler {
 }
 
 func (h *HTTPHandler) Register(e *echo.Echo) {
-	e.GET("/v1/auth/check", h.checkAuth)
 
 	// materiaal
 	e.GET("/v1/materiaal/objects", h.getMateriaalObjects)
 	e.GET("/v1/materiaal/klant/:mvmnummer", h.getMateriaalForKlant)
 	e.POST("/v1/materiaal/klant/:mvmnummer", h.postMateriaalForKlant)
 	e.POST("/v1/sinterklaas/klant/:mvmnummer", h.postSinterklaasForKlant)
-}
 
-func (h *HTTPHandler) checkAuth(c echo.Context) error {
-	user := c.Get("user").(*jwt.Token)
-	claims := user.Claims.(*auth.Claim)
-	if claims.Name == "" {
-		return c.JSON(http.StatusUnauthorized, echo.Map{"status": "JWT incorrect"})
-	}
-	return c.JSON(http.StatusOK, echo.Map{"status": "ok"})
+	//whoami
+	e.GET("/v1/auth/check", h.checkAuth)
+	e.GET("/v1/whoami/roles", h.getRoles)
 }

--- a/pkg/api/v1/whoami.go
+++ b/pkg/api/v1/whoami.go
@@ -1,0 +1,45 @@
+package v1
+
+import (
+	"net/http"
+
+	"github.com/dgrijalva/jwt-go"
+	"github.com/moedersvoormoeders/api.mvm.digital/pkg/api/auth"
+
+	"github.com/labstack/echo/v4"
+	"github.com/moedersvoormoeders/api.mvm.digital/pkg/db"
+)
+
+func (h *HTTPHandler) getRoles(c echo.Context) error {
+	roles := []db.Role{}
+
+	user, ok := c.Get("user").(*jwt.Token)
+	if !ok {
+		return c.JSON(http.StatusUnauthorized, echo.Map{"status": "JWT incorrect"})
+	}
+	claims, ok := user.Claims.(*auth.Claim)
+	if !ok || claims.Name == "" {
+		return c.JSON(http.StatusUnauthorized, echo.Map{"status": "JWT incorrect"})
+	}
+
+	roleBindings := []db.RoleBinding{}
+	res := h.db.Preload("Role.Verbs").Preload("Role.Endpoints").Where("user_id = ?", claims.ID).Find(&roleBindings)
+	if res.Error != nil {
+		return c.JSON(http.StatusBadRequest, echo.Map{"error": res.Error.Error()})
+	}
+
+	for _, rb := range roleBindings {
+		roles = append(roles, rb.Role)
+	}
+
+	return c.JSON(http.StatusOK, roles)
+}
+
+func (h *HTTPHandler) checkAuth(c echo.Context) error {
+	user := c.Get("user").(*jwt.Token)
+	claims := user.Claims.(*auth.Claim)
+	if claims.Name == "" {
+		return c.JSON(http.StatusUnauthorized, echo.Map{"status": "JWT incorrect"})
+	}
+	return c.JSON(http.StatusOK, echo.Map{"status": "ok"})
+}

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -57,6 +57,10 @@ func (c *Connection) DoMigrate() error {
 		&MateriaalEntry{},
 		&MateriaalObject{},
 		&MateriaalMaat{},
+		&RoleEndpoint{},
+		&RoleVerb{},
+		&Role{},
+		&RoleBinding{},
 	)
 	if err != nil {
 		return err

--- a/pkg/db/rbac.go
+++ b/pkg/db/rbac.go
@@ -1,0 +1,32 @@
+package db
+
+import (
+	"github.com/jinzhu/gorm"
+)
+
+type RoleVerb struct {
+	gorm.Model
+	Content   string
+	RoleRefer uint
+}
+
+type RoleEndpoint struct {
+	gorm.Model
+	Content   string
+	RoleRefer uint
+}
+
+type Role struct {
+	gorm.Model
+	Name      string
+	Verbs     []RoleVerb     `gorm:"foreignKey:RoleRefer"`
+	Endpoints []RoleEndpoint `gorm:"foreignKey:RoleRefer"`
+}
+
+type RoleBinding struct {
+	gorm.Model
+	UserID int
+	User   User
+	RoleID int
+	Role   Role
+}

--- a/pkg/db/rbac.go
+++ b/pkg/db/rbac.go
@@ -6,27 +6,27 @@ import (
 
 type RoleVerb struct {
 	gorm.Model
-	Content   string
-	RoleRefer uint
+	Content   string `json:"content"`
+	RoleRefer uint   `json:"roleRefer"`
 }
 
 type RoleEndpoint struct {
 	gorm.Model
-	Content   string
-	RoleRefer uint
+	Content   string `json:"content"`
+	RoleRefer uint   `json:"roleRefer"`
 }
 
 type Role struct {
 	gorm.Model
-	Name      string
+	Name      string         `json:"name"`
 	Verbs     []RoleVerb     `gorm:"foreignKey:RoleRefer"`
 	Endpoints []RoleEndpoint `gorm:"foreignKey:RoleRefer"`
 }
 
 type RoleBinding struct {
 	gorm.Model
-	UserID int
-	User   User
-	RoleID int
-	Role   Role
+	UserID int  `json:"userID"`
+	User   User `json:"user"`
+	RoleID int  `json:"roleID"`
+	Role   Role `json:"role"`
 }


### PR DESCRIPTION
This adds a role system for users to limit access to endpoints, the GUI will also query this to show and hide options.
The system is heavily inspired by Kubernetes and allows to limit HTTP verbs as well as paths in the API with globing.

fixes https://github.com/moedersvoormoeders/api.mvm.digital/issues/7